### PR TITLE
Fixed typo in the export dialog

### DIFF
--- a/pymacros/vector_file_export_dialog.py
+++ b/pymacros/vector_file_export_dialog.py
@@ -531,7 +531,7 @@ class VectorFileExportDialog(pya.QDialog, ProgressReporter):
         if settings.content_scaling_style == ContentScaling.FIGURE_WIDTH_MM:
             self.on_figure_width_changed()
         elif settings.content_scaling_style == ContentScaling.SCALING:
-            self.on_scaling_changed()
+            self.on_scaling_value_changed()
         else:
             raise NotImplementedError(f"Unhandled enum case {settings.content_scaling_style}")
 


### PR DESCRIPTION
Fixed the typo `on_scaling_changed` in the `vector_file_export_dialog.py` to the correct `on_scaling_value_changed` fixes https://github.com/iic-jku/klayout-vector-file-export/issues/28